### PR TITLE
Bugs/3 renderhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
 .settings
 .project
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
-*.class
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.ear
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
+.settings
+.project
+target/
+.classpath
+*.i[mpw][lrs]
+.idea/
+!faces.taglib.xml
+!jsp.taglib.tld
+.scala_dependencies
+nb-configuration.xml
+*~
+rebel.xml
+.springBeans
+workbench.xmi

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
 		<maven.compiler.optimize>true</maven.compiler.optimize>
 		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 		<!-- allowed values: R7, 1.0, 1.5, 2.0 or none -->
 		<jetty9.version>9.2.11.v20150529</jetty9.version>
 		<log4j.version>1.2.17</log4j.version>
@@ -181,7 +181,11 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.3</version>
+					<version>3.5.1</version>
+					<configuration>
+						<source>${maven.compiler.source}</source>
+						<target>${maven.compiler.target}</target>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -189,6 +193,25 @@
 					<version>2.10</version>
 					<configuration>
 						<downloadSources>true</downloadSources>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-toolchains-plugin</artifactId>
+					<version>1.1</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>toolchain</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<toolchains>
+							<jdk>
+								<version>${maven.compiler.source}</version>
+							</jdk>
+						</toolchains>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/main/java/org/apache/wicket/extensions/markup/html/tree/AbstractTree.java
+++ b/src/main/java/org/apache/wicket/extensions/markup/html/tree/AbstractTree.java
@@ -16,6 +16,21 @@
  */
 package org.apache.wicket.extensions.markup.html.tree;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreeNode;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.WicketRuntimeException;
@@ -39,13 +54,6 @@ import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.string.AppendingStringBuffer;
 import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
-
-import javax.swing.event.TreeModelEvent;
-import javax.swing.event.TreeModelListener;
-import javax.swing.tree.TreeModel;
-import javax.swing.tree.TreeNode;
-import java.io.Serializable;
-import java.util.*;
 
 
 /**

--- a/src/main/java/org/apache/wicket/extensions/markup/html/tree/AbstractTree.java
+++ b/src/main/java/org/apache/wicket/extensions/markup/html/tree/AbstractTree.java
@@ -16,21 +16,6 @@
  */
 package org.apache.wicket.extensions.markup.html.tree;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.swing.event.TreeModelEvent;
-import javax.swing.event.TreeModelListener;
-import javax.swing.tree.TreeModel;
-import javax.swing.tree.TreeNode;
-
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.WicketRuntimeException;
@@ -54,6 +39,13 @@ import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.string.AppendingStringBuffer;
 import org.apache.wicket.util.visit.IVisit;
 import org.apache.wicket.util.visit.IVisitor;
+
+import javax.swing.event.TreeModelEvent;
+import javax.swing.event.TreeModelListener;
+import javax.swing.tree.TreeModel;
+import javax.swing.tree.TreeNode;
+import java.io.Serializable;
+import java.util.*;
 
 
 /**
@@ -264,9 +256,8 @@ public abstract class AbstractTree extends Panel
 		}
 
 		@Override
-		public void renderHead(final IHeaderResponse response)
-		{
-			super.renderHead(response);
+		public void internalRenderHead(final HtmlHeaderContainer container) {
+			super.internalRenderHead(container);
 
 			if (isRenderChildren())
 			{
@@ -278,7 +269,7 @@ public abstract class AbstractTree extends Panel
 					{
 						if (item.isVisible())
 						{
-							item.renderHead(response);
+							item.internalRenderHead(container);
 						}
 
 						// write header contributions from the children of item
@@ -290,7 +281,7 @@ public abstract class AbstractTree extends Panel
 							{
 								if (component.isVisible())
 								{
-									component.renderHead(response);
+									component.internalRenderHead(container);
 								}
 								else
 								{

--- a/src/test/java/org/apache/wicket/extensions/markup/html/tree/TreeTablePageTest.java
+++ b/src/test/java/org/apache/wicket/extensions/markup/html/tree/TreeTablePageTest.java
@@ -48,11 +48,14 @@ public class TreeTablePageTest {
 		tester.clickLink("tree:i:0:sideBodyColumns:0:comp:link");
 		MockHttpServletResponse opaLinkResponse = tester.getLastResponse();
 
-		String opaResponseBody = opaLinkResponse.getDocument();
+		final String opaResponseBody = opaLinkResponse.getDocument();
 
 		// assert that all rendered AJAX links their client side event handlers are registered 
-		page.visitChildren(AjaxLink.class, (v, r) -> {
-			assertThat(opaResponseBody, containsString("\"c\":\"" + v.getMarkupId() + "\""));
+		page.visitChildren(AjaxLink.class, new IVisitor<AjaxLink, Void>() {
+			@Override
+			public void component(AjaxLink ajaxLink, IVisit<Void> iVisit) {
+				assertThat(opaResponseBody, containsString("\"c\":\"" + ajaxLink.getMarkupId() + "\""));
+			}
 		});
 
 //		tester.clickLink("tree:i:2:sideBodyColumns:0:comp:link");

--- a/src/test/java/org/apache/wicket/extensions/markup/html/tree/TreeTablePageTest.java
+++ b/src/test/java/org/apache/wicket/extensions/markup/html/tree/TreeTablePageTest.java
@@ -16,14 +16,16 @@
  */
 package org.apache.wicket.extensions.markup.html.tree;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
-
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.protocol.http.mock.MockHttpServletResponse;
 import org.apache.wicket.util.tester.WicketTester;
+import org.apache.wicket.util.visit.IVisit;
+import org.apache.wicket.util.visit.IVisitor;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
 
 public class TreeTablePageTest {
 	private WicketTester tester;


### PR DESCRIPTION
This fixes #3 by turning `AbstractTree$TreeItem#renderHead` into `internalRenderHead` as it should have been.

I also reverted the project to Java 7, because inmethod-grid works with 7, and the code in here doesn't really need Java 8.

What can I do to have this jar released and inmethod-grid updated as well?
