### PR TITLE
Build against Wicket 9.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,15 +280,12 @@
 	</build>
 	<profiles>
 		<profile>
-			<id>Java 8</id>
+			<id>Java 11</id>
 			<activation>
-				<jdk>1.8</jdk>
+				<jdk>11</jdk>
 			</activation>
 			<properties>
-				<!-- Disable javadoc linter when building with Java 8
-				http://mail-archives.apache.org/mod_mbox/maven-users/201403.mbox/%3CCANWgJS5xHWiGE+Lecey+mZVbj9Via4JUWsaBeZtQr2aQNebupA@mail.gmail.com%3E
-				http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html
-				-->
+				<!-- Disable javadoc linter when building with Java 11 -->
 				<additionalparam>-Xdoclint:-html</additionalparam>
 			</properties>
 		</profile>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<groupId>org.wicketstuff</groupId>
 	<artifactId>wicket15-tree</artifactId>
 	<packaging>jar</packaging>
-	<version>8.0.1-SNAPSHOT</version>
+	<version>9.0.0-SNAPSHOT</version>
 	<name>Wicket 1.5 Tree component</name>
 	<description>A copy of the pre- Wicket-6.x Tree component from wicket-extensions</description>
 	<licenses>
@@ -35,15 +35,15 @@
 		<maven.compiler.optimize>true</maven.compiler.optimize>
 		<maven.compiler.showDeprecation>true</maven.compiler.showDeprecation>
 		<maven.compiler.showWarnings>true</maven.compiler.showWarnings>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<!-- allowed values: R7, 1.0, 1.5, 2.0 or none -->
 		<jetty.version>9.4.7.v20170914</jetty.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<junit.version>4.12</junit.version>
 		<servlet-api.version>3.1.0</servlet-api.version>
 		<wtp.version>none</wtp.version>
-		<wicket.version>8.0.0</wicket.version>
+		<wicket.version>9.0.0</wicket.version>
 	</properties>
 	<scm>
 		<connection>scm:git:git@github.com:wicketstuff/wicket1.5-tree.git</connection>

--- a/src/main/java/org/apache/wicket/extensions/markup/html/tree/Tree.java
+++ b/src/main/java/org/apache/wicket/extensions/markup/html/tree/Tree.java
@@ -25,7 +25,6 @@ import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.model.AbstractReadOnlyModel;
 import org.apache.wicket.model.IModel;
 
 
@@ -96,7 +95,7 @@ public class Tree extends DefaultAbstractTree
 
 		nodeLink.add(newNodeIcon(nodeLink, "icon", node));
 
-		nodeLink.add(new Label("label", new AbstractReadOnlyModel<String>()
+		nodeLink.add(new Label("label", new IModel<String>()
 		{
 			private static final long serialVersionUID = 1L;
 
@@ -115,8 +114,7 @@ public class Tree extends DefaultAbstractTree
 			private static final long serialVersionUID = 1L;
 
 			/**
-			 * @see org.apache.wicket.behavior.AbstractBehavior#onComponentTag(org.apache.wicket.
-			 *      Component, ComponentTag)
+			 * @see org.apache.wicket.behavior.Behavior#onComponentTag(Component, ComponentTag)
 			 */
 			@Override
 			public void onComponentTag(final Component component, final ComponentTag tag)

--- a/src/main/java/org/apache/wicket/extensions/markup/html/tree/table/TreeTable.java
+++ b/src/main/java/org/apache/wicket/extensions/markup/html/tree/table/TreeTable.java
@@ -32,7 +32,6 @@ import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Fragment;
-import org.apache.wicket.model.AbstractReadOnlyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.request.resource.CssResourceReference;
 import org.apache.wicket.request.resource.ResourceReference;
@@ -96,12 +95,12 @@ public class TreeTable extends DefaultAbstractTree
 
 			nodeLink.add(newNodeIcon(nodeLink, "icon", node));
 
-			nodeLink.add(new Label("label", new AbstractReadOnlyModel<String>()
+			nodeLink.add(new Label("label", new IModel<String>()
 			{
 				private static final long serialVersionUID = 1L;
 
 				/**
-				 * @see AbstractReadOnlyModel#getObject()
+				 * @see IModel#getObject()
 				 */
 				@Override
 				public String getObject()


### PR DESCRIPTION
Unfortunately, we still have a dependency on the old Wicket1.5-tree, and using it with Wicket 9 resulted in runtime errors as the `AbstractReadOnlyModel` is no longer available.

I've created a new `wicket-9.x` branch which builds against Wicket 9 (no more `AbstractReadOnlyModel` and Java11). 

Hopefully, nobody else needs this :-)